### PR TITLE
Fix a TextFied color bug in iOS7

### DIFF
--- a/lib/src/util/tools.dart
+++ b/lib/src/util/tools.dart
@@ -6,7 +6,7 @@ String _color2rgb(int color) {
 
   int r = (color >> 16) & 0xFF;
   int g = (color >>  8) & 0xFF;
-  int b = (color >>  0) & 0xFF;
+  int b = color & 0xFF;
 
   return "rgb($r,$g,$b)";
 }
@@ -16,7 +16,7 @@ String _color2rgba(int color) {
   int a = (color >> 24) & 0xFF;
   int r = (color >> 16) & 0xFF;
   int g = (color >>  8) & 0xFF;
-  int b = (color >>  0) & 0xFF;
+  int b = color & 0xFF;
 
   return "rgba($r,$g,$b,${a / 255.0})";
 }


### PR DESCRIPTION
This patch fixes a bug in iOS 7 where a white TextField (0xffffff) becomes yellow (0xffff00) after 3 seconds (if cacheAsBitmap is disabled).
I suppose this is a bug in an optimization of Safari but making this little change solved the problem.
