### PR TITLE
Exception 'ImageElement' is not a subtype of type 'CanvasElement'

### DIFF
--- a/lib/src/display/graphics_pattern.dart
+++ b/lib/src/display/graphics_pattern.dart
@@ -36,7 +36,12 @@ class GraphicsPattern {
   Matrix get matrix => _matrix;
   
   CanvasPattern getCanvasPattern(CanvasRenderingContext2D context) {
-    return context.createPattern(_bitmapData._source, _repeatOption);
+    CanvasImageSource source = _bitmapData._source;
+    if(source is ImageElement) {
+      return context.createPatternFromImage(source, _repeatOption);
+    } else {
+      return context.createPattern(source, _repeatOption);
+    }
   }
 
 }


### PR DESCRIPTION
If the source of the BitmapData is of type ImageElement, we have the exception "type 'ImageElement' is not a subtype of type 'CanvasElement' of 'canvas'" when we use it in a GraphicsPattern.
