### PR TITLE
Enable sound on IEMobile/10.0

### DIFF
--- a/lib/src/media/implementation/audio_element_sound.dart
+++ b/lib/src/media/implementation/audio_element_sound.dart
@@ -35,11 +35,11 @@ class AudioElementSound extends Sound {
       return MockSound.load(url, soundLoadOptions);
     }
 
-    StreamSubscription onCanPlayThroughSubscription;
+    StreamSubscription onCanPlaySubscription;
     StreamSubscription onErrorSubscription;
 
-    onCanPlayThrough(event) {
-      onCanPlayThroughSubscription.cancel();
+    onCanPlay(event) {
+      onCanPlaySubscription.cancel();
       onErrorSubscription.cancel();
       loadCompleter.complete(sound);
     };
@@ -49,7 +49,7 @@ class AudioElementSound extends Sound {
         audio.src = audioUrls.removeAt(0);
         audio.load();
       } else {
-        onCanPlayThroughSubscription.cancel();
+        onCanPlaySubscription.cancel();
         onErrorSubscription.cancel();
 
         if (soundLoadOptions.ignoreErrors) {
@@ -60,7 +60,7 @@ class AudioElementSound extends Sound {
       }
     };
 
-    onCanPlayThroughSubscription = audio.onCanPlayThrough.listen(onCanPlayThrough);
+    onCanPlaySubscription = audio.onCanPlay.listen(onCanPlay);
     onErrorSubscription = audio.onError.listen(onError);
 
     audio.src = audioUrls.removeAt(0);

--- a/lib/src/media/sound_mixer.dart
+++ b/lib/src/media/sound_mixer.dart
@@ -53,7 +53,7 @@ class SoundMixer {
     var ua = html.window.navigator.userAgent;
 
     if (ua.contains("IEMobile")) {
-      if (ua.contains("9.0") || ua.contains("10.0")) {
+      if (ua.contains("9.0")) {
         _engine = "Mock";
       }
     }


### PR DESCRIPTION
Hello Bernhard,
AudioElement can actually works on IEMobile 10.0 (Windows Phone 8) but that requires to use the onCanPlay event in place of the onCanPlayThrough.

What do you think? Would it be acceptable?

It could probably also works on IEMobile 9.0 but don't have any device to test.
