### PR TITLE
Crash in Dartium when assigning an int to the alpha property

### DIFF
--- a/lib/src/display/display_object.dart
+++ b/lib/src/display/display_object.dart
@@ -179,8 +179,8 @@ abstract class DisplayObject extends EventDispatcher implements BitmapDrawable {
 
   set alpha(num value) {
     if (value is num) {
-      if (value < 0.0) value = 0.0;
-      if (value > 1.0) value = 1.0;
+      if (value <= 0.0) value = 0.0;
+      if (value >= 1.0) value = 1.0;
       _alpha = value;
     }
   }


### PR DESCRIPTION
Hello,
I have a bug that make Dartium crash (aw, snap) but unfortunately, I'm not able to reproduce it in a small sample.
This is weird because I have no error message and it works in javascript.

I discovered that if in my code I change:
myField.alpha = 0;
to
myField.alpha = 0.0;
Then it works correctly.
So I propose this small change that solve my problem.

Maybe you have an idea of what the root cause can be and how to fix the problem in a different way.

Thank you.
