### PR TITLE
Infinite loop in Juggler.purge()

### DIFF
--- a/lib/src/animation/juggler.dart
+++ b/lib/src/animation/juggler.dart
@@ -128,13 +128,9 @@ class Juggler implements Animatable {
 
   //-----------------------------------------------------------------------------------------------
 
-  void purge() {
-
-    var link = _firstAnimatableLink;
-    while(identical(link, _lastAnimatableLink) == false) {
-      link.animatable = null;
-    }
-
+  void clear() {
+    _firstAnimatableLink.animatable = null;
+    _firstAnimatableLink.nextAnimatableLink = null;
     _lastAnimatableLink = _firstAnimatableLink;
   }
 


### PR DESCRIPTION
Hello,
I think there is a bug in the purge() method of Juggler. It's an infinite loop.
Also as it was basically unusable, it should not be a big breaking change to rename it to the more common name "clear"?

What do you think?
