### PR TITLE
Enable mask, shadow and filters on Stage

### DIFF
--- a/lib/src/display/stage.dart
+++ b/lib/src/display/stage.dart
@@ -332,7 +332,7 @@ class Stage extends DisplayObjectContainer {
       _renderState._currentTime = _ensureNum(currentTime);
       _renderState._deltaTime = _ensureNum(deltaTime);
 
-      render(_renderState);
+      _renderInternal(_renderState);
 
       _renderState.flush();
 


### PR DESCRIPTION
Hello Bernhard,
The Stage class inherit from DisplayObject and thus have a mask, shadow and filters properties. But it is not rendered. This small change enable this.

If it was intentionally left out because of side effects, feel free to discard my PR.

Thank you.
