### PR TITLE
Fix bug in audio_element_sound implementation

### DIFF
--- a/lib/src/media/implementation/audio_element_sound.dart
+++ b/lib/src/media/implementation/audio_element_sound.dart
@@ -107,7 +107,7 @@ class AudioElementSound extends Sound {
   //-------------------------------------------------------------------------------------------------
 
   void _onAudioEnded(html.Event event) {
-    var soundChannel = _soundChannels.firstWhere((sc) => identical(sc._audio, event.target));
+    var soundChannel = _soundChannels.firstWhere((sc) => identical(sc._audio, event.target), orElse: () => null);
     if (soundChannel != null) soundChannel.stop();
   }
 


### PR DESCRIPTION
Hello Bernhard,
I encounter sometimes an error in IE when playing audio: "Bad state: No element" coming from "_onAudioEnded".

The fix seems easy enough and works for me.
