### PR TITLE
Expose BitmapFilterProgram publically to allow external extend

### DIFF
--- a/lib/src/filters/alpha_mask_filter.dart
+++ b/lib/src/filters/alpha_mask_filter.dart
@@ -61,7 +61,7 @@ class AlphaMaskFilter extends BitmapFilter {
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
 
-class _AlphaMaskProgram extends _BitmapFilterProgram {
+class _AlphaMaskProgram extends BitmapFilterProgram {
 
   static final _AlphaMaskProgram instance = new _AlphaMaskProgram();
 

--- a/lib/src/filters/bitmap_filter_program.dart
+++ b/lib/src/filters/bitmap_filter_program.dart
@@ -1,6 +1,6 @@
 part of stagexl.filters;
 
-abstract class _BitmapFilterProgram extends RenderProgram {
+abstract class BitmapFilterProgram extends RenderProgram {
 
   String get vertexShaderSource => """
       attribute vec2 aVertexPosition;

--- a/lib/src/filters/blur_filter.dart
+++ b/lib/src/filters/blur_filter.dart
@@ -89,7 +89,7 @@ class BlurFilter extends BitmapFilter {
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
 
-class _BlurProgram extends _BitmapFilterProgram {
+class _BlurProgram extends BitmapFilterProgram {
 
   static final _BlurProgram instance = new _BlurProgram();
 

--- a/lib/src/filters/chroma_key_filter.dart
+++ b/lib/src/filters/chroma_key_filter.dart
@@ -60,7 +60,7 @@ class ChromaKeyFilter extends BitmapFilter {
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
 
-class _ChromaKeyProgram extends _BitmapFilterProgram {
+class _ChromaKeyProgram extends BitmapFilterProgram {
 
   static final _ChromaKeyProgram instance = new _ChromaKeyProgram();
 

--- a/lib/src/filters/color_matrix_filter.dart
+++ b/lib/src/filters/color_matrix_filter.dart
@@ -217,7 +217,7 @@ class ColorMatrixFilter extends BitmapFilter {
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
 
-class _ColorMatrixProgram extends _BitmapFilterProgram {
+class _ColorMatrixProgram extends BitmapFilterProgram {
 
   static final _ColorMatrixProgram instance = new _ColorMatrixProgram();
 

--- a/lib/src/filters/displacement_map_filter.dart
+++ b/lib/src/filters/displacement_map_filter.dart
@@ -109,7 +109,7 @@ class DisplacementMapFilter extends BitmapFilter {
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
 
-class _DisplacementMapProgram extends _BitmapFilterProgram {
+class _DisplacementMapProgram extends BitmapFilterProgram {
 
   static final _DisplacementMapProgram instance = new _DisplacementMapProgram();
 

--- a/lib/src/filters/drop_shadow_filter.dart
+++ b/lib/src/filters/drop_shadow_filter.dart
@@ -114,7 +114,7 @@ class DropShadowFilter extends BitmapFilter {
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
 
-class _DropShadowProgram extends _BitmapFilterProgram {
+class _DropShadowProgram extends BitmapFilterProgram {
 
   static final _DropShadowProgram instance = new _DropShadowProgram();
 

--- a/lib/src/filters/glow_filter.dart
+++ b/lib/src/filters/glow_filter.dart
@@ -97,7 +97,7 @@ class GlowFilter extends BitmapFilter {
 //-------------------------------------------------------------------------------------------------
 //-------------------------------------------------------------------------------------------------
 
-class _GlowProgram extends _BitmapFilterProgram {
+class _GlowProgram extends BitmapFilterProgram {
 
   static final _GlowProgram instance = new _GlowProgram();
 


### PR DESCRIPTION
Hi  Bernhard,

Here's is a little pull request that change put the class _BitmapFilterProgram into BitmapFilterProgram.
This let users extend the class be able to create their own WebGL filter out of the StabeXL library.

In my case, I would use this to create a WebGL filter that fit exactly my need, but it is too specific to be useful inside StageXL itself.
