### PR TITLE
Make the constructor of AudioElementSound & WebAudioApiSound public

### DIFF
--- a/lib/src/media/implementation/audio_element_sound.dart
+++ b/lib/src/media/implementation/audio_element_sound.dart
@@ -6,7 +6,7 @@ class AudioElementSound extends Sound {
   final List<AudioElement> _audioPool = new List<AudioElement>();
   final List<AudioElementSoundChannel> _soundChannels = new List<AudioElementSoundChannel>();
 
-  AudioElementSound._(AudioElement audio) : _audio = audio {
+  AudioElementSound(AudioElement audio) : _audio = audio {
     _audio.onEnded.listen(_onAudioEnded);
     _audioPool.add(_audio);
   }
@@ -24,7 +24,7 @@ class AudioElementSound extends Sound {
     var audioLoader = new AudioLoader(audioUrls, loadData, corsEnabled);
 
     audioLoader.done.then((AudioElement audioElement) {
-      completer.complete(new AudioElementSound._(audioElement));
+      completer.complete(new AudioElementSound(audioElement));
     }).catchError((error) {
       if (soundLoadOptions.ignoreErrors) {
         MockSound.load(url, soundLoadOptions).then((s) => completer.complete(s));

--- a/lib/src/media/implementation/web_audio_api_sound.dart
+++ b/lib/src/media/implementation/web_audio_api_sound.dart
@@ -2,9 +2,9 @@ part of stagexl.media;
 
 class WebAudioApiSound extends Sound {
 
-  AudioBuffer _buffer;
+  final AudioBuffer _buffer;
 
-  WebAudioApiSound._() {
+  WebAudioApiSound(this._buffer) {
     if (SoundMixer.engine != "WebAudioApi") {
       throw new UnsupportedError("This browser does not support Web Audio API.");
     }
@@ -17,7 +17,6 @@ class WebAudioApiSound extends Sound {
 
     if (soundLoadOptions == null) soundLoadOptions = Sound.defaultLoadOptions;
 
-    var sound = new WebAudioApiSound._();
     var loadCompleter = new Completer<Sound>();
     var audioUrls = soundLoadOptions.getOptimalAudioUrls(url);
     var audioContext = WebAudioApiMixer.audioContext;
@@ -28,7 +27,7 @@ class WebAudioApiSound extends Sound {
 
     audioRequestFinished(request) {
       audioContext.decodeAudioData(request.response).then((AudioBuffer buffer) {
-        sound._buffer = buffer;
+        var sound = new WebAudioApiSound(buffer);
         loadCompleter.complete(sound);
       }).catchError((error) {
         if (soundLoadOptions.ignoreErrors) {


### PR DESCRIPTION
Hello Bernhard,
I would like to make public the constructors of the 2 implementations of Sound.

This is because we are loading our sounds with a single json file where each sound is encoded in base64. We can decode it to AudioBuffer or AudioElement and we would like to create a StageXL Sound for the sake of simplicity.

If you see a problem with that, feel free to close this pull request.  I can copy the implementation in my code.

Thank you.