### PR TITLE
Support BitmapDataLoadOptions for TextureAtlas with ResourceManager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ packages
 
 # Include when developing application packages.
 pubspec.lock
+
+# IDE files
+.idea/
+*.iml

--- a/lib/src/resources/resource_manager.dart
+++ b/lib/src/resources/resource_manager.dart
@@ -112,8 +112,8 @@ class ResourceManager {
     _addResource("SoundSprite", name, url, SoundSprite.load(url));
   }
 
-  void addTextureAtlas(String name, String url, TextureAtlasFormat textureAtlasFormat) {
-    _addResource("TextureAtlas", name, url, TextureAtlas.load(url, textureAtlasFormat));
+  void addTextureAtlas(String name, String url, TextureAtlasFormat textureAtlasFormat, [BitmapDataLoadOptions bitmapDataLoadOptions = null]) {
+    _addResource("TextureAtlas", name, url, TextureAtlas.load(url, textureAtlasFormat, bitmapDataLoadOptions));
   }
 
   void addTextFile(String name, String url) {


### PR DESCRIPTION
This is a simple change to allow setting the BitmapDataLoadOptions when adding a TextureAtlas to a ResourceManager.

I was running into CORS issues and couldn't set corsEnabled for loading texture atlases when using a resource mananger.