### PR TITLE
Allow to set Stage.devicePixelRatio

### DIFF
--- a/lib/src/display/bitmap_data.dart
+++ b/lib/src/display/bitmap_data.dart
@@ -73,7 +73,7 @@ class BitmapData implements BitmapDrawable {
     if (pixelRatioMatch != null) {
       var match = pixelRatioMatch;
       var originPixelRatio = int.parse(match.group(1));
-      var devicePixelRatio = env.devicePixelRatio.round();
+      var devicePixelRatio = Stage.devicePixelRatio.round();
       var loaderPixelRatio = minInt(devicePixelRatio, maxPixelRatio);
       pixelRatio = loaderPixelRatio / originPixelRatio;
       url = url.replaceRange(match.start, match.end, "@${loaderPixelRatio}x");

--- a/lib/src/display/display_object.dart
+++ b/lib/src/display/display_object.dart
@@ -880,7 +880,7 @@ abstract class DisplayObject
 
   void applyCache(int x, int y, int width, int height, {bool debugBorder: false}) {
 
-    var pixelRatio = Stage.autoHiDpi ? env.devicePixelRatio : 1.0;
+    var pixelRatio = Stage.autoHiDpi ? Stage.devicePixelRatio : 1.0;
 
     var renderTexture = _cacheTextureQuad == null
         ? new RenderTexture(width, height, Color.Transparent, pixelRatio)

--- a/lib/src/display/stage.dart
+++ b/lib/src/display/stage.dart
@@ -13,7 +13,7 @@ class Stage extends DisplayObjectContainer {
 
   static bool autoHiDpi = env.autoHiDPI;
   static bool get isMobile => env.isMobileDevice;
-  static num get devicePixelRatio => env.devicePixelRatio;
+  static num devicePixelRatio = env.devicePixelRatio;
 
   CanvasElement _canvas;
   RenderContext _renderContext;

--- a/lib/src/resources/texture_atlas_format.dart
+++ b/lib/src/resources/texture_atlas_format.dart
@@ -34,7 +34,7 @@ class _TextureAtlasFormatJson extends TextureAtlasFormat {
     if (pixelRatioMatch != null) {
       var match = pixelRatioMatch;
       var originPixelRatio = int.parse(match.group(1));
-      var devicePixelRatio = env.devicePixelRatio.round();
+      var devicePixelRatio = Stage.devicePixelRatio.round();
       var loaderPixelRatio = minInt(devicePixelRatio, maxPixelRatio);
       pixelRatio = loaderPixelRatio / originPixelRatio;
       url = url.replaceRange(match.start, match.end, "@${loaderPixelRatio}x");
@@ -99,7 +99,7 @@ class _TextureAtlasFormatLibGDX extends TextureAtlasFormat {
     if (pixelRatioMatch != null) {
       var match = pixelRatioMatch;
       var originPixelRatio = int.parse(match.group(1));
-      var devicePixelRatio = env.devicePixelRatio.round();
+      var devicePixelRatio = Stage.devicePixelRatio.round();
       var loaderPixelRatio = minInt(devicePixelRatio, maxPixelRatio);
       pixelRatio = loaderPixelRatio / originPixelRatio;
       url = url.replaceRange(match.start, match.end, "@${loaderPixelRatio}x");

--- a/lib/src/text/text_field.dart
+++ b/lib/src/text/text_field.dart
@@ -514,7 +514,7 @@ class TextField extends InteractiveObject {
       _refreshPending &= 255 - 2;
     }
 
-    var pixelRatio = Stage.autoHiDpi ? env.devicePixelRatio : 1.0;
+    var pixelRatio = Stage.autoHiDpi ? Stage.devicePixelRatio : 1.0;
     var width = max(1, _width).ceil();
     var height =  max(1, _height).ceil();
 


### PR DESCRIPTION
Hello Bernhard,
This PR allows to change the static property Stage.devicePixelRatio and uses it in place of the env.devicePixelRatio.

We can implement our own "hi-definition" logic from the outside like this:
```dart
if (window.screen.width > 960 || window.screen.height > 540) {
  Stage.autoHiDpi = true;
  Stage.devicePixelRatio = 2.0;
}
```

This allows us to have high-definition for big screen with a devicePixelRatio of 1 (ie a PC with a screen of 1920x1080).
It results in much better quality in textfield or in sprite with "applyCache".

As always feel free to implement it in a better way :-)