### PR TITLE
Small RenderLoop and Juggler changes.

### DIFF
--- a/lib/src/animation/juggler.dart
+++ b/lib/src/animation/juggler.dart
@@ -47,6 +47,10 @@ class Juggler implements Animatable {
 
   /// The elapsed time since the juggler has started.
 
+  bool get hasAnimatables => _firstAnimatableLink.animatable != null;
+
+  /// The elapsed time since the juggler has started.
+
   num get elapsedTime => _elapsedTime;
 
   /// A stream of [elapsedTime] changes.

--- a/lib/src/display/render_loop.dart
+++ b/lib/src/display/render_loop.dart
@@ -4,13 +4,13 @@ class RenderLoop extends RenderLoopBase {
 
   final Juggler juggler = new Juggler();
 
-  List<Stage> _stages = new List<Stage>();
-  bool _invalidate = false;
-  num _currentTime = 0.0;
+  List<Stage> stages = new List<Stage>();
+  bool bInvalidate = false;
+  num currentTime = 0.0;
 
-  EnterFrameEvent _enterFrameEvent = new EnterFrameEvent(0);
-  ExitFrameEvent _exitFrameEvent = new ExitFrameEvent();
-  RenderEvent _renderEvent = new RenderEvent();
+  EnterFrameEvent enterFrameEvent = new EnterFrameEvent(0);
+  ExitFrameEvent exitFrameEvent = new ExitFrameEvent();
+  RenderEvent renderEvent = new RenderEvent();
 
   RenderLoop() {
     this.start();
@@ -19,7 +19,7 @@ class RenderLoop extends RenderLoopBase {
   //-------------------------------------------------------------------------------------------------
 
   void invalidate() {
-    _invalidate = true;
+    bInvalidate = true;
   }
 
   void addStage(Stage stage) {
@@ -28,14 +28,14 @@ class RenderLoop extends RenderLoopBase {
       stage.renderLoop.removeStage(stage);
     }
 
-    _stages.add(stage);
+    stages.add(stage);
     stage._renderLoop = this;
   }
 
   void removeStage(Stage stage) {
 
     if (stage.renderLoop == this) {
-      _stages.remove(stage);
+      stages.remove(stage);
       stage._renderLoop = null;
     }
   }
@@ -44,26 +44,26 @@ class RenderLoop extends RenderLoopBase {
 
   void advanceTime(num deltaTime) {
 
-    _currentTime += deltaTime;
+    currentTime += deltaTime;
 
-    _enterFrameEvent.passedTime = deltaTime;
-    _enterFrameEvent.dispatch();
+    enterFrameEvent.passedTime = deltaTime;
+    enterFrameEvent.dispatch();
 
     juggler.advanceTime(deltaTime);
 
-    for (int i = 0; i < _stages.length; i++) {
-      _stages[i].juggler.advanceTime(deltaTime);
+    for (int i = 0; i < stages.length; i++) {
+      stages[i].juggler.advanceTime(deltaTime);
     }
 
-    if (_invalidate) {
-      _invalidate = false;
-      _renderEvent.dispatch();
+    if (bInvalidate) {
+      bInvalidate = false;
+      renderEvent.dispatch();
     }
 
-    for (int i = 0; i < _stages.length; i++) {
-      _stages[i].materialize(_currentTime, deltaTime);
+    for (int i = 0; i < stages.length; i++) {
+      stages[i].materialize(currentTime, deltaTime);
     }
 
-    _exitFrameEvent.dispatch();
+    exitFrameEvent.dispatch();
   }
 }


### PR DESCRIPTION
Hi Bernhard,

for my framework I created an alternate RenderLoop, which only materializes a Stage if "something is going on" in its Juggler. To make this possible, I am requesting two changes to StageXL, which I hope you will accept the one way or the other :-)

1) lib/src/display/render_loop.dart
Make class members of RenderLoop public – otherwise there's no accessing them when extending RenderLoop.

2) lib/src/animation/juggler.dart
Add a getter to Juggler indicating whether it has Animatables to process, i.e. is "busy".

In my demo, this brings down CPU load from 50% to 3% in "idle" situations.
Thanks,
Nils