### PR TITLE
Changes to fix Pop Pop Win with Dart 1.16 (new WebGL IDL)

### DIFF
--- a/lib/src/engine/render_buffer_index.dart
+++ b/lib/src/engine/render_buffer_index.dart
@@ -38,7 +38,7 @@ class RenderBufferIndex {
       _renderingContext = renderContext.rawContext;
       _buffer = _renderingContext.createBuffer();
       _renderingContext.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, _buffer);
-      _renderingContext.bufferDataTyped(gl.ELEMENT_ARRAY_BUFFER, data, usage);
+      _renderingContext.bufferData(gl.ELEMENT_ARRAY_BUFFER, data, usage);
     }
 
     _renderingContext.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, _buffer);
@@ -46,7 +46,7 @@ class RenderBufferIndex {
 
   void update() {
     var update = new Int16List.view(data.buffer, 0, this.position);
-    _renderingContext.bufferSubDataTyped(gl.ELEMENT_ARRAY_BUFFER, 0, update);
+    _renderingContext.bufferSubData(gl.ELEMENT_ARRAY_BUFFER, 0, update);
   }
 
 }

--- a/lib/src/engine/render_buffer_vertex.dart
+++ b/lib/src/engine/render_buffer_vertex.dart
@@ -38,7 +38,7 @@ class RenderBufferVertex {
       _renderingContext = renderContext.rawContext;
       _buffer = _renderingContext.createBuffer();
       _renderingContext.bindBuffer(gl.ARRAY_BUFFER, _buffer);
-      _renderingContext.bufferDataTyped(gl.ARRAY_BUFFER, data, usage);
+      _renderingContext.bufferData(gl.ARRAY_BUFFER, data, usage);
     }
 
     _renderingContext.bindBuffer(gl.ARRAY_BUFFER, _buffer);
@@ -46,7 +46,7 @@ class RenderBufferVertex {
 
   void update() {
     var update = new Float32List.view(data.buffer, 0, this.position);
-    _renderingContext.bufferSubDataTyped(gl.ARRAY_BUFFER, 0, update);
+    _renderingContext.bufferSubData(gl.ARRAY_BUFFER, 0, update);
   }
 
   void bindAttribute(int index, int size, int stride, int offset) {

--- a/lib/src/engine/render_texture.dart
+++ b/lib/src/engine/render_texture.dart
@@ -153,7 +153,7 @@ class RenderTexture {
       var type = gl.UNSIGNED_BYTE;
 
       _renderContext.activateRenderTexture(this);
-      _renderingContext.texImage2DTyped(target, 0, rgba, _width, _height, 0, rgba, type, null);
+      _renderingContext.texImage2D(target, 0, rgba, _width, _height, 0, rgba, type, null);
 
     } else {
 
@@ -186,10 +186,10 @@ class RenderTexture {
     if (_textureSourceWorkaround) {
       _canvas.context2D.drawImage(_source, 0, 0);
       _renderContext.activateRenderTexture(this);
-      _renderingContext.texImage2DCanvas(target, 0, rgba, rgba, type, _canvas);
+      _renderingContext.texImage2D(target, 0, rgba, rgba, type, _canvas);
     } else {
       _renderContext.activateRenderTexture(this);
-      _renderingContext.texImage2DUntyped(target, 0, rgba, rgba, type, _source);
+      _renderingContext.texImage2D(target, 0, rgba, rgba, type, _source);
     }
   }
 
@@ -212,17 +212,17 @@ class RenderTexture {
       _renderingContext.bindTexture(target, _texture);
 
       if (_source != null) {
-        _renderingContext.texImage2DUntyped(target, 0, rgba, rgba, type, _source);
+        _renderingContext.texImage2D(target, 0, rgba, rgba, type, _source);
         _textureSourceWorkaround = _renderingContext.getError() == gl.INVALID_VALUE;
       } else {
-        _renderingContext.texImage2DTyped(target, 0, rgba, width, height, 0, rgba, type, null);
+        _renderingContext.texImage2D(target, 0, rgba, width, height, 0, rgba, type, null);
       }
 
       if (_textureSourceWorkaround) {
         // WEBGL11072: INVALID_VALUE: texImage2D: This texture source is not supported
         _canvas = new CanvasElement(width: width, height: height);
         _canvas.context2D.drawImage(_source, 0, 0);
-        _renderingContext.texImage2DCanvas(target, 0, rgba, rgba, type, _canvas);
+        _renderingContext.texImage2D(target, 0, rgba, rgba, type, _canvas);
       }
 
       _renderingContext.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ author: Bernhard Pichler <support@stagexl.org>
 description: A fast and universal 2D rendering engine for HTML5 and Dart.
 homepage: http://www.stagexl.org
 environment:
-  sdk: '>=1.13.0 <2.0.0'
+  sdk: '>=1.16.0 <2.0.0'
 documentation: http://www.stagexl.org/docs/api/index.html
 dependencies:
   xml: any


### PR DESCRIPTION
Not sure what you want to do in terms of versions and SDK constraints, but this fixes a number of changed methods in Dart 1.16 where we've regenerated WebGL from updated Chrome IDL and various things have changed. There are probably others, this is just the obvious things that broke Pop Pop Win.