### PR TITLE
Add support for playing opus audio files

### DIFF
--- a/lib/src/internal/audio_loader.dart
+++ b/lib/src/internal/audio_loader.dart
@@ -91,6 +91,7 @@ class AudioLoader {
     if (valid.indexOf(audio.canPlayType("audio/mpeg")) != -1) supportedTypes.add("mp3");
     if (valid.indexOf(audio.canPlayType("audio/mp4")) != -1) supportedTypes.add("mp4");
     if (valid.indexOf(audio.canPlayType("audio/ogg")) != -1) supportedTypes.add("ogg");
+    if (valid.indexOf(audio.canPlayType("audio/ogg; codecs=opus")) != -1) supportedTypes.add("opus");
     if (valid.indexOf(audio.canPlayType("audio/ac3")) != -1) supportedTypes.add("ac3");
     if (valid.indexOf(audio.canPlayType("audio/wav")) != -1) supportedTypes.add("wav");
 

--- a/lib/src/media/sound_load_options.dart
+++ b/lib/src/media/sound_load_options.dart
@@ -21,6 +21,9 @@ class SoundLoadOptions {
 
   bool ogg = true;
 
+  /// The application provides *opus* files as an option to load audio files.
+  bool opus = true;
+
   /// The application provides *ac3* files as an option to load audio files.
 
   bool ac3 = true;
@@ -32,7 +35,7 @@ class SoundLoadOptions {
   /// A list of alternative urls for sound samples in the case where the
   /// primary url does not work or the file type is not supported by the
   /// browser. If this value is null, the alternative urls are calcualted
-  /// automatically based on the mp3, mp4, ogg, ac3 and wav properties.
+  /// automatically based on the mp3, mp4, ogg, opus, ac3 and wav properties.
 
   List<String> alternativeUrls;
 
@@ -55,6 +58,7 @@ class SoundLoadOptions {
     options.mp3 = this.mp3;
     options.mp4 = this.mp4;
     options.ogg = this.ogg;
+    options.opus = this.opus;
     options.ac3 = this.ac3;
     options.wav = this.wav;
     options.alternativeUrls = urls == null ? null : urls.toList();
@@ -74,6 +78,7 @@ class SoundLoadOptions {
     if (!this.mp3) availableTypes.remove("mp3");
     if (!this.mp4) availableTypes.remove("mp4");
     if (!this.ogg) availableTypes.remove("ogg");
+    if (!this.opus) availableTypes.remove("opus");
     if (!this.ac3) availableTypes.remove("ac3");
     if (!this.wav) availableTypes.remove("wav");
 


### PR DESCRIPTION
Opus info - http://caniuse.com/#search=opus

Unfortunately, there's currently a bug in chrome that prevents opus files from playing - https://bugs.chromium.org/p/chromium/issues/detail?id=409402

This pull request results in opus files playing succesfully in Firefox, and it should work when Chrome fixes the above bug.