### PR TITLE
Specify engine used by SoundMixer

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -5,8 +5,8 @@ In alphabetical order:
 Alex Gann <https://github.com/alexgann>  
 Andrew Gerard <https://github.com/kinetifex>  
 Arron Washington <https://github.com/radicaled>  
-Bernhard Pichler <https://github.com/bp74>
-Josh Brown <https://github.com/joshwritescode>
+Bernhard Pichler <https://github.com/bp74>  
+Josh Brown <https://github.com/joshwritescode>  
 Kevin Moore <https://github.com/kevmoo>  
 Marco Jakob <https://github.com/marcojakob>  
 Mark Nordine <https://github.com/mnordine>  

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -5,7 +5,8 @@ In alphabetical order:
 Alex Gann <https://github.com/alexgann>  
 Andrew Gerard <https://github.com/kinetifex>  
 Arron Washington <https://github.com/radicaled>  
-Bernhard Pichler <https://github.com/bp74>  
+Bernhard Pichler <https://github.com/bp74>
+Josh Brown <https://github.com/joshwritescode>
 Kevin Moore <https://github.com/kevmoo>  
 Marco Jakob <https://github.com/marcojakob>  
 Mark Nordine <https://github.com/mnordine>  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ announcements on the StageXL forum or use one of the support links below:
   * StageXL GitHub <https://github.com/bp74/StageXL/issues>
   * StageXL StackOverflow: <http://stackoverflow.com/questions/ask?tags=stagexl>
 
+#### Pub version 0.13.8+1
+  * Added support for specifying the sound engine in StageXL.soundLoadOptions.
+
 #### Pub version 0.13.8
   * Added support for opus audio codec.
   * Added support for SoundLoadOptions in Sound.loadDataUrl.

--- a/lib/src/media.dart
+++ b/lib/src/media.dart
@@ -37,6 +37,7 @@ part 'media/sound.dart';
 part 'media/sound_channel.dart';
 part 'media/sound_load_options.dart';
 part 'media/sound_mixer.dart';
+part 'media/sound_engines.dart';
 part 'media/sound_transform.dart';
 part 'media/video.dart';
 part 'media/video_load_options.dart';

--- a/lib/src/media/sound.dart
+++ b/lib/src/media/sound.dart
@@ -3,6 +3,7 @@ part of stagexl.media;
 abstract class Sound {
 
   Sound() {
+    SoundMixer.engine = Sound.defaultLoadOptions.soundEngine;
     SoundMixer._initEngine();
   }
 
@@ -29,9 +30,9 @@ abstract class Sound {
 
   static Future<Sound> load(String url, [SoundLoadOptions soundLoadOptions]) {
     switch(SoundMixer.engine) {
-      case "WebAudioApi" :
+      case SoundEngines.WebAudioApi :
         return WebAudioApiSound.load(url, soundLoadOptions);
-      case "AudioElement":
+      case SoundEngines.AudioElement:
         return AudioElementSound.load(url, soundLoadOptions);
       default :
         return MockSound.load(url, soundLoadOptions);
@@ -46,13 +47,12 @@ abstract class Sound {
   ///     var future = Sound.loadDataUrl("data:audio/mpeg;base64,<data>");
   ///     future.then((Sound sound) => sound.play());
 
-  static Future<Sound> loadDataUrl(
-      String dataUrl, [SoundLoadOptions soundLoadOptions]) {
+  static Future<Sound> loadDataUrl(String dataUrl, [SoundLoadOptions soundLoadOptions]) {
 
     switch(SoundMixer.engine) {
-      case "WebAudioApi" :
+      case SoundEngines.WebAudioApi:
         return WebAudioApiSound.loadDataUrl(dataUrl, soundLoadOptions);
-      case "AudioElement":
+      case SoundEngines.AudioElement:
         return AudioElementSound.loadDataUrl(dataUrl, soundLoadOptions);
       default :
         return MockSound.loadDataUrl(dataUrl, soundLoadOptions);

--- a/lib/src/media/sound_engines.dart
+++ b/lib/src/media/sound_engines.dart
@@ -1,0 +1,9 @@
+part of stagexl.media;
+
+class SoundEngines
+{
+  static const String WebAudioApi = "WebAudioApi";
+  static const String AudioElement = "AudioElement";
+
+  SoundEngines();
+}

--- a/lib/src/media/sound_load_options.dart
+++ b/lib/src/media/sound_load_options.dart
@@ -49,6 +49,10 @@ class SoundLoadOptions {
 
   bool corsEnabled = false;
 
+  /// Bypass the audio engine detection logic to use a specific audio engine.
+
+  String soundEngine;
+
   //---------------------------------------------------------------------------
 
   /// Create a deep clone of this [SoundLoadOptions].
@@ -62,6 +66,7 @@ class SoundLoadOptions {
     options.opus = this.opus;
     options.ac3 = this.ac3;
     options.wav = this.wav;
+    options.soundEngine = this.soundEngine;
     options.alternativeUrls = urls == null ? null : urls.toList();
     options.ignoreErrors = this.ignoreErrors;
     options.corsEnabled = this.corsEnabled;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: stagexl
-version: 0.13.8
+version: 0.13.8+1
 author: Bernhard Pichler <support@stagexl.org>
 description: A fast and universal 2D rendering engine for HTML5 and Dart.
 homepage: http://www.stagexl.org


### PR DESCRIPTION
There's a new SoundEngines class with static constants for valid sound engine types.
You can now set the sound engine to be used by calling:

StageXL.soundLoadOptions.soundEngine = SoundEngines.AudioElement;

If set in this manner, the logic that is used to determine which sound engine to use in SoundMixer._initEngine() is overlooked in favor of the engine that is set in soundLoadOptions.1

I've updated the version to 0.13.8+1, but you can obviously change that to whatever you want.