### PR TITLE
First attempt at StageRenderMode.AUTO_DIRTY

### DIFF
--- a/lib/src/display/stage.dart
+++ b/lib/src/display/stage.dart
@@ -6,7 +6,8 @@ part of stagexl.display;
 enum StageRenderMode {
   AUTO,
   STOP,
-  ONCE
+  ONCE,
+  AUTO_DIRTY
 }
 
 /// The StageScaleMode defines how the Stage is scaled inside of the Canvas.
@@ -59,6 +60,7 @@ class Stage extends DisplayObjectContainer {
   int _stageWidth = 0;
   int _stageHeight = 0;
   num _pixelRatio = 1.0;
+  bool _dirty = true;
 
   Rectangle<num> _contentRectangle = new Rectangle<num>(0.0, 0.0, 0.0, 0.0);
   Matrix _clientTransformation = new Matrix.fromIdentity();
@@ -253,6 +255,12 @@ class Stage extends DisplayObjectContainer {
     _updateCanvasSize();
   }
 
+  /// Gets and sets the qualification of the Stage for rendering.
+  bool get dirty => _dirty;
+  set dirty(bool dirty){
+    _dirty = dirty;
+  }
+
   /// Gets and sets the render mode of this Stage. You can choose between
   /// three different modes defined in [StageRenderMode].
 
@@ -354,8 +362,7 @@ class Stage extends DisplayObjectContainer {
 
   void materialize(num currentTime, num deltaTime) {
 
-    if (_stageRenderMode == StageRenderMode.AUTO ||
-        _stageRenderMode == StageRenderMode.ONCE) {
+    if (_stageRenderMode != StageRenderMode.STOP) {
 
       _updateCanvasSize();
 


### PR DESCRIPTION
@bp74, @kevmoo – minimal invasive attempt at implementing an idle render mode. 

It introduces a getter/setter `dirty` to `Stage` and sets it to true in `RenderLoop` whenever MOUSE_MOVE, TOUCH_MOVE or MOUSE_WHEEL events are fired. Also in `RenderLoop`, the `advanceTime` method was altered to only call `Stage.materialize`, if either the `Stage.dirty`property is `true`, or if a `Juggler` has something to animate.

The logic only kicks in if renderMode is set to `StageRenderMode.AUTO_DIRTY`, which is why I don't think it is a problem to not introduce automagic to:
* Juggler.onElapsedTimeChange
* Juggler.timespan
* ENTER_FRAME
* Shaders with animation

I noticed following issues (also see comments further down) I'd love to hear your thoughts on:
* If the only thing running are juggler animations, then their last frame is not rendered anymore because `Juggler.hasAnimatables` is already `false` after `Juggler.advanceTime`, leading to `materialize`not being invoked.
* It seems mouse cursors are affected when 'pausing' the render loop – if there's a useHandCursor on a Button, the hand only shows for short time, going back to pointer. I didn't yet check if this is the same case with `StageRenderMode.ONCE`