### PR TITLE
Don't call drawImageScaledFromSource if source size is 0

### DIFF
--- a/lib/src/engine/render_context_canvas.dart
+++ b/lib/src/engine/render_context_canvas.dart
@@ -105,6 +105,8 @@ class RenderContextCanvas extends RenderContext {
     var matrix = renderState.globalMatrix;
     var alpha = renderState.globalAlpha;
     var blendMode = renderState.globalBlendMode;
+    
+    if (sourceRect.width <= 0 || sourceRect.height <= 0) return;
 
     if (_activeAlpha != alpha) {
       _activeAlpha = alpha;


### PR DESCRIPTION
Firefox and InternetExplorer throw an exception if the source width or height is equals to zero in drawImageScaledFromSource . 
It can happen with Scale9Bitmap for instance.