### PR TITLE
Fixes false positives of Dart2's linter

### DIFF
--- a/lib/src/display/display_object.dart
+++ b/lib/src/display/display_object.dart
@@ -1019,6 +1019,7 @@ abstract class DisplayObject extends EventDispatcher
       obj1 = obj1.parent;
       depth1 -= 1;
     }
+    // ignore: invariant_booleans
     while (depth2 > depth1) {
       obj2 = obj2.parent;
       depth2 -= 1;

--- a/lib/src/display_ex/time_gauge.dart
+++ b/lib/src/display_ex/time_gauge.dart
@@ -31,6 +31,7 @@ class TimeGauge extends Gauge implements Animatable {
   bool advanceTime(num time) {
     if (_isStarted && ratio > 0.0) {
       ratio = ratio - time / totalTime;
+      // ignore: invariant_booleans
       if (ratio == 0.0) pause();
     }
     return true;


### PR DESCRIPTION
Another Dart 2 preparation: Added line based ignores where linter gives false positives on `invariant_booleans`.