### PR TITLE
moved blending logic to `BlendMode`

### DIFF
--- a/lib/src/engine/blend_mode.dart
+++ b/lib/src/engine/blend_mode.dart
@@ -8,6 +8,11 @@ class BlendMode {
 
   const BlendMode(this.srcFactor, this.dstFactor, this.compositeOperation);
 
+  void blend(gl.RenderingContext renderingContext) {
+    renderingContext.blendFunc(srcFactor, dstFactor);
+    renderingContext.blendEquation(gl.WebGL.FUNC_ADD);
+  }
+
   /// The display object appears in front of the background. Pixel values of the
   /// display object override those of the background. Where the display object
   /// is transparent, the background is visible.

--- a/lib/src/engine/render_context_webgl.dart
+++ b/lib/src/engine/render_context_webgl.dart
@@ -468,7 +468,7 @@ class RenderContextWebGL extends RenderContext {
     if (!identical(blendMode, _activeBlendMode)) {
       _activeRenderProgram.flush();
       _activeBlendMode = blendMode;
-      _renderingContext.blendFunc(blendMode.srcFactor, blendMode.dstFactor);
+      _activeBlendMode.blend(_renderingContext);
     }
   }
 


### PR DESCRIPTION
A solution for #336
The logic necessary for blending is moved to a `BlendingMode`'s method.
Now the user could define more complicated blendings, e.g.:
```dart
class EquationBlendMode extends BlendMode {
  const EquationBlendMode(int mode, String compositeOperation)
      : super(mode, null, compositeOperation);

  @override
  void blend(gl.RenderingContext renderingContext) {
    var ext = renderingContext.getExtension('EXT_blend_minmax');
    assert(ext != null);
    renderingContext.blendEquation(srcFactor);
  }
}
```

The `null` in the constructor looks a bit messy, but I guess this is the only way to add custom behavior and not break any existing code which might rely on the public fields `srcFactor` and `dstFactor`.