### PR TITLE
Update null safety to 2.12 and remove redundant experiment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ announcements on the StageXL forum or use one of the support links below:
   * StageXL GitHub <https://github.com/bp74/StageXL/issues>
   * StageXL StackOverflow: <http://stackoverflow.com/questions/ask?tags=stagexl>
 
+### 2.0.0-nullsafety.0
+  * Upgrade to null safety
+  * Update Dart SDK restraint to >= 2.12.0-0
+  
 #### 1.4.6
   * Upgraded to latest package versions
   * Allow overriding blend mode function

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,1 @@
-analyzer:
-  enable-experiment:
-    - non-nullable
-
 include: package:pedantic/analysis_options.yaml

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,18 +1,15 @@
 name: stagexl
-version: 1.4.7
+version: 2.0.0-nullsafety.0
 description: A fast and universal 2D rendering engine for HTML5 and Dart.
 homepage: http://www.stagexl.org
 
 environment:
-  sdk: '>=2.10.0 <3.0.0'
+  sdk: '>=2.12.0-0 <3.0.0'
 
 documentation: http://www.stagexl.org/docs/api/index.html
 
 dependencies:
-  xml:
-    git:
-      url: https://github.com/renggli/dart-xml.git
-      ref: nullsafety
+  xml: '^5.0.0-nullsafety.1'
 
 dev_dependencies:
   test: any


### PR DESCRIPTION
As outlined in the [Null safety beta post](https://medium.com/dartlang/announcing-dart-null-safety-beta-87610fee6730) it's time to start migrating packages on pub.

I updated the SDK constraint to 2.12.0-0 as quoting the article:

> Apps and packages will only run with null safety if their minimum Dart SDK constraint is at least a Dart 2.12 prerelease

I updated the StageXL version to 2.0.0 as it is recommend to upgrade to the next major version and this is a rather major change. As this is still a prelease(signaled by the `-nullsafety.0`) this time can also be used to make other breaking changes if desired.