### PR TITLE
Use xhr to load images, use createImageBitmap and ImageBitmap

### DIFF
--- a/lib/src/display.dart
+++ b/lib/src/display.dart
@@ -16,8 +16,7 @@ library stagexl.display;
 import 'dart:async';
 import 'dart:collection';
 import 'dart:html' as html;
-import 'dart:html' show ImageElement, VideoElement;
-import 'dart:html' show CanvasElement;
+import 'dart:html' show CanvasElement, ImageElement, VideoElement, ImageBitmap;
 import 'dart:math' hide Point, Rectangle;
 import 'dart:typed_data';
 
@@ -26,6 +25,7 @@ import 'drawing.dart';
 import 'engine.dart';
 import 'events.dart';
 import 'geom.dart';
+import 'internal/image_bitmap_loader.dart';
 import 'internal/environment.dart' as env;
 import 'internal/image_loader.dart';
 import 'internal/tools.dart';

--- a/lib/src/display/bitmap_data.dart
+++ b/lib/src/display/bitmap_data.dart
@@ -43,6 +43,13 @@ class BitmapData implements BitmapDrawable {
     return BitmapData.fromRenderTextureQuad(renderTextureQuad);
   }
 
+  factory BitmapData.fromImageBitmap(ImageBitmap imageBitmap,
+      [num pixelRatio = 1.0]) {
+    var renderTexture = RenderTexture.fromImageBitmap(imageBitmap);
+    var renderTextureQuad = renderTexture.quad.withPixelRatio(pixelRatio);
+    return BitmapData.fromRenderTextureQuad(renderTextureQuad);
+  }
+
   factory BitmapData.fromVideoElement(VideoElement videoElement,
       [num pixelRatio = 1.0]) {
     final renderTexture = RenderTexture.fromVideoElement(videoElement);
@@ -60,11 +67,18 @@ class BitmapData implements BitmapDrawable {
 
   /// Loads a BitmapData from the given url.
 
-  static Future<BitmapData> load(String url, [BitmapDataLoadOptions? options]) {
+  static Future<BitmapData> load(String url, [BitmapDataLoadOptions? options]) async {
     options = options ?? BitmapData.defaultLoadOptions;
     final bitmapDataFileInfo = BitmapDataLoadInfo(url, options.pixelRatios);
     final targetUrl = bitmapDataFileInfo.loaderUrl;
     final pixelRatio = bitmapDataFileInfo.pixelRatio;
+
+    if (options.imageBitmap) {
+      final loader = ImageBitmapLoader(targetUrl, options.webp);
+      final imageBitmap = await loader.done;
+      return BitmapData.fromImageBitmap(imageBitmap, pixelRatio);
+    }
+
     final loader = ImageLoader(targetUrl, options.webp, options.corsEnabled);
     return loader.done.then((i) => BitmapData.fromImageElement(i, pixelRatio));
   }

--- a/lib/src/display/bitmap_data.dart
+++ b/lib/src/display/bitmap_data.dart
@@ -73,7 +73,7 @@ class BitmapData implements BitmapDrawable {
     final targetUrl = bitmapDataFileInfo.loaderUrl;
     final pixelRatio = bitmapDataFileInfo.pixelRatio;
 
-    if (options.imageBitmap) {
+    if (env.isImageBitmapSupported) {
       final loader = ImageBitmapLoader(targetUrl, options.webp);
       final imageBitmap = await loader.done;
       return BitmapData.fromImageBitmap(imageBitmap, pixelRatio);

--- a/lib/src/display/bitmap_data_load_options.dart
+++ b/lib/src/display/bitmap_data_load_options.dart
@@ -75,6 +75,10 @@ class BitmapDataLoadOptions {
 
   bool corsEnabled = false;
 
+  /// Load images via imageBitmap. Does decoding off main thread,
+  /// but not supported on all browsers
+  bool imageBitmap = false;
+
   //---------------------------------------------------------------------------
 
   /// Create a deep clone of this [BitmapDataLoadOptions].

--- a/lib/src/display/bitmap_data_load_options.dart
+++ b/lib/src/display/bitmap_data_load_options.dart
@@ -75,10 +75,6 @@ class BitmapDataLoadOptions {
 
   bool corsEnabled = false;
 
-  /// Load images via imageBitmap. Does decoding off main thread,
-  /// but not supported on all browsers
-  bool imageBitmap = false;
-
   //---------------------------------------------------------------------------
 
   /// Create a deep clone of this [BitmapDataLoadOptions].

--- a/lib/src/engine.dart
+++ b/lib/src/engine.dart
@@ -22,7 +22,9 @@ import 'dart:html'
         CanvasRenderingContext2D,
         CanvasImageSource,
         ImageData,
+        ImageBitmap,
         VideoElement;
+import 'dart:js_util' as js_util;
 import 'dart:math' as math;
 import 'dart:typed_data';
 import 'dart:web_gl' as gl;

--- a/lib/src/engine/render_context_canvas.dart
+++ b/lib/src/engine/render_context_canvas.dart
@@ -99,7 +99,9 @@ class RenderContextCanvas extends RenderContext {
     }
 
     final context = _renderingContext;
-    final source = renderTextureQuad.renderTexture.source;
+    final source = renderTextureQuad.renderTexture.source
+      ?? renderTextureQuad.renderTexture.imageBitmap;
+
     final rotation = renderTextureQuad.rotation;
     final sourceRect = renderTextureQuad.sourceRectangle;
     final vxList = renderTextureQuad.vxListQuad;
@@ -117,10 +119,13 @@ class RenderContextCanvas extends RenderContext {
       context.globalCompositeOperation = blendMode.compositeOperation;
     }
 
+    // Note: We need to use js_util.callMethod for the drawImage calls,
+    // since Dart SDK does not support ImageBitmap as a CanvasImageSource
+
     if (rotation == 0) {
       context.setTransform(
           matrix.a, matrix.b, matrix.c, matrix.d, matrix.tx, matrix.ty);
-      context.drawImageScaledFromSource(
+      js_util.callMethod(context, 'drawImage', [
           source!,
           sourceRect.left,
           sourceRect.top,
@@ -129,11 +134,12 @@ class RenderContextCanvas extends RenderContext {
           vxList[0],
           vxList[1],
           vxList[8] - vxList[0],
-          vxList[9] - vxList[1]);
+          vxList[9] - vxList[1]
+      ]);
     } else if (rotation == 1) {
       context.setTransform(
           -matrix.c, -matrix.d, matrix.a, matrix.b, matrix.tx, matrix.ty);
-      context.drawImageScaledFromSource(
+      js_util.callMethod(context, 'drawImage', [
           source!,
           sourceRect.left,
           sourceRect.top,
@@ -142,11 +148,12 @@ class RenderContextCanvas extends RenderContext {
           0.0 - vxList[13],
           vxList[12],
           vxList[9] - vxList[1],
-          vxList[8] - vxList[0]);
+          vxList[8] - vxList[0]
+      ]);
     } else if (rotation == 2) {
       context.setTransform(
           -matrix.a, -matrix.b, -matrix.c, -matrix.d, matrix.tx, matrix.ty);
-      context.drawImageScaledFromSource(
+      js_util.callMethod(context, 'drawImage', [
           source!,
           sourceRect.left,
           sourceRect.top,
@@ -155,11 +162,12 @@ class RenderContextCanvas extends RenderContext {
           0.0 - vxList[8],
           0.0 - vxList[9],
           vxList[8] - vxList[0],
-          vxList[9] - vxList[1]);
+          vxList[9] - vxList[1]
+      ]);
     } else if (rotation == 3) {
       context.setTransform(
           matrix.c, matrix.d, -matrix.a, -matrix.b, matrix.tx, matrix.ty);
-      context.drawImageScaledFromSource(
+      js_util.callMethod(context, 'drawImage', [
           source!,
           sourceRect.left,
           sourceRect.top,
@@ -168,7 +176,8 @@ class RenderContextCanvas extends RenderContext {
           vxList[5],
           0.0 - vxList[4],
           vxList[9] - vxList[1],
-          vxList[8] - vxList[0]);
+          vxList[8] - vxList[0]
+      ]);
     }
   }
 

--- a/lib/src/engine/render_texture.dart
+++ b/lib/src/engine/render_texture.dart
@@ -4,7 +4,10 @@ class RenderTexture {
   int _width = 0;
   int _height = 0;
 
-  CanvasImageSource? _source;
+  // TODO: Make CanvasImageSource again once
+  // https://github.com/dart-lang/sdk/issues/12379#issuecomment-572239799
+  // is addressed
+  /*CanvasImageSource*/dynamic _source;
   CanvasElement? _canvas;
   RenderTextureFiltering _filtering = RenderTextureFiltering.LINEAR;
   RenderTextureWrapping _wrappingX = RenderTextureWrapping.CLAMP;
@@ -39,6 +42,12 @@ class RenderTexture {
     _source = imageElement;
   }
 
+  RenderTexture.fromImageBitmap(ImageBitmap image) {
+    _width = image.width!;
+    _height = image.height!;
+    _source = image;
+  }
+
   RenderTexture.fromCanvasElement(CanvasElement canvasElement) {
     _width = canvasElement.width!;
     _height = canvasElement.height!;
@@ -61,7 +70,11 @@ class RenderTexture {
 
   int get width => _width;
   int get height => _height;
-  CanvasImageSource? get source => _source;
+
+  CanvasImageSource? get source {
+    if (_source is CanvasImageSource) return _source as CanvasImageSource?;
+    return null;
+  }
 
   RenderTextureQuad get quad => RenderTextureQuad(
       this,
@@ -78,9 +91,29 @@ class RenderTexture {
       _canvas = _source = CanvasElement(width: _width, height: _height);
       _canvas!.context2D.drawImageScaled(imageElement, 0, 0, _width, _height);
       return _canvas!;
+    } else if (_source is ImageBitmap) {
+      final image = _source as ImageBitmap;
+      _canvas = _source = CanvasElement(width: _width, height: _height);
+
+      // Note: We need to use js_util.callMethod, because Dart SDK
+      // does not support ImageBitmap as a CanvasImageSource
+      js_util.callMethod(_canvas!.context2D, 'drawImage', [
+        image,
+        0,
+        0,
+        _width,
+        _height,
+      ]);
+
+      return _canvas!;
     } else {
       throw StateError('RenderTexture is read only.');
     }
+  }
+
+  ImageBitmap? get imageBitmap {
+    if (_source is ImageBitmap) return _source as ImageBitmap?;
+    return null;
   }
 
   gl.Texture? get texture => _texture;
@@ -151,6 +184,10 @@ class RenderTexture {
       _renderingContext?.deleteTexture(_texture);
     }
 
+    if (_source is ImageBitmap) {
+      (_source as ImageBitmap).close();
+    }
+
     _texture = null;
     _source = null;
     _canvas = null;
@@ -214,7 +251,7 @@ class RenderTexture {
     if (scissors) _renderingContext!.disable(gl.WebGL.SCISSOR_TEST);
 
     if (_textureSourceWorkaround) {
-      _canvas!.context2D.drawImage(_source!, 0, 0);
+      _canvas!.context2D.drawImage(source!, 0, 0);
       _renderingContext!.texImage2D(target, 0, rgba, rgba, type, _canvas);
     } else {
       _renderingContext!.texImage2D(target, 0, rgba, rgba, type, _source);
@@ -254,7 +291,7 @@ class RenderTexture {
       if (_textureSourceWorkaround) {
         // WEBGL11072: INVALID_VALUE: texImage2D: This texture source is not supported
         _canvas = CanvasElement(width: width, height: height);
-        _canvas!.context2D.drawImage(_source!, 0, 0);
+        _canvas!.context2D.drawImage(source!, 0, 0);
         renderingContext.texImage2D(target, 0, rgba, rgba, type, _canvas);
       }
 

--- a/lib/src/internal/environment.dart
+++ b/lib/src/internal/environment.dart
@@ -1,6 +1,7 @@
 library stagexl.internal.environment;
 
 import 'dart:async';
+import 'dart:js' as js;
 import 'dart:html';
 import 'dart:typed_data';
 
@@ -10,6 +11,7 @@ final Future<bool> isWebpSupported = _checkWebpSupport();
 final bool isMobileDevice = _checkMobileDevice();
 final bool isLittleEndianSystem = _checkLittleEndianSystem();
 final bool isTouchEventSupported = _checkTouchEventSupport();
+bool get isImageBitmapSupported => js.context['createImageBitmap'] != null;
 
 //-------------------------------------------------------------------------------------
 

--- a/lib/src/internal/image_bitmap_loader.dart
+++ b/lib/src/internal/image_bitmap_loader.dart
@@ -1,0 +1,63 @@
+library stagexl.internal.image_bitmap_loader;
+
+import 'dart:async';
+import 'dart:html';
+import 'dart:js_util';
+
+import 'environment.dart' as env;
+
+class ImageBitmapLoader {
+  final String _url;
+  final _completer = Completer<ImageBitmap>();
+  HttpRequest? _request;
+
+  ImageBitmapLoader(String url, bool webpAvailable) : _url = url {
+    if (webpAvailable) {
+      env.isWebpSupported.then(_onWebpSupported);
+    } else {
+      _load(url);
+    }
+  }
+
+  void _load(String url) {
+    final request = _request = HttpRequest();
+    request
+      ..onReadyStateChange.listen((_) async {
+        if (request.readyState == HttpRequest.DONE && request.status == 200) {
+          try {
+            final blob = request.response as Blob;
+
+            // Note: Dart SDK does not support createImageBitmap, so
+            // use callMethod and convert from promise to future.
+            // See https://github.com/dart-lang/sdk/issues/12379
+            final promise = callMethod(window, 'createImageBitmap', [blob]);
+            final imageBitmap =
+              await promiseToFuture<ImageBitmap>(promise as Object);
+
+            _completer.complete(imageBitmap);
+          } catch (e) {
+            _completer.completeError(e);
+          }
+        }
+      })
+      ..onError.listen(_completer.completeError)
+      ..open('GET', url, async: true)
+      ..responseType = 'blob'
+      ..send();
+  }
+
+  void cancel() => _request?.abort();
+
+  //---------------------------------------------------------------------------
+
+  Future<ImageBitmap> get done => _completer.future;
+
+  //---------------------------------------------------------------------------
+
+  void _onWebpSupported(bool webpSupported) {
+    var match = RegExp(r'(png|jpg|jpeg)$').firstMatch(_url);
+    if (webpSupported && match != null) {
+      _load(_url);
+    }
+  }
+}

--- a/lib/src/resources.dart
+++ b/lib/src/resources.dart
@@ -18,6 +18,7 @@ import 'package:xml/xml.dart';
 import 'display.dart';
 import 'engine.dart';
 import 'geom.dart';
+import 'internal/image_bitmap_loader.dart';
 import 'internal/image_loader.dart';
 import 'internal/tools.dart';
 import 'media.dart';

--- a/lib/src/resources.dart
+++ b/lib/src/resources.dart
@@ -18,6 +18,7 @@ import 'package:xml/xml.dart';
 import 'display.dart';
 import 'engine.dart';
 import 'geom.dart';
+import 'internal/environment.dart' as env;
 import 'internal/image_bitmap_loader.dart';
 import 'internal/image_loader.dart';
 import 'internal/tools.dart';

--- a/lib/src/resources/texture_atlas_loader.dart
+++ b/lib/src/resources/texture_atlas_loader.dart
@@ -41,7 +41,7 @@ class _TextureAtlasLoaderFile extends TextureAtlasLoader {
     final imageUrl = replaceFilename(loaderUrl, filename);
     final RenderTexture renderTexture;
 
-    if (_loadOptions.imageBitmap) {
+    if (env.isImageBitmapSupported) {
       final loader = ImageBitmapLoader(imageUrl, webpAvailable);
       final imageBitmap = await loader.done;
       renderTexture = RenderTexture.fromImageBitmap(imageBitmap);

--- a/lib/src/resources/texture_atlas_loader.dart
+++ b/lib/src/resources/texture_atlas_loader.dart
@@ -37,15 +37,23 @@ class _TextureAtlasLoaderFile extends TextureAtlasLoader {
   @override
   Future<RenderTextureQuad> getRenderTextureQuad(String filename) async {
     final loaderUrl = _loadInfo.loaderUrl;
-    final pixelRatio = _loadInfo.pixelRatio;
     final webpAvailable = _loadOptions.webp;
-    final corsEnabled = _loadOptions.corsEnabled;
     final imageUrl = replaceFilename(loaderUrl, filename);
-    final imageLoader = ImageLoader(imageUrl, webpAvailable, corsEnabled);
-    final imageElement = await imageLoader.done;
-    final renderTexture = RenderTexture.fromImageElement(imageElement);
-    final renderTextureQuad = renderTexture.quad.withPixelRatio(pixelRatio);
-    return renderTextureQuad;
+    final RenderTexture renderTexture;
+
+    if (_loadOptions.imageBitmap) {
+      final loader = ImageBitmapLoader(imageUrl, webpAvailable);
+      final imageBitmap = await loader.done;
+      renderTexture = RenderTexture.fromImageBitmap(imageBitmap);
+    } else {
+      final corsEnabled = _loadOptions.corsEnabled;
+      final loader = ImageLoader(imageUrl, webpAvailable, corsEnabled);
+      final imageElement = await loader.done;
+      renderTexture = RenderTexture.fromImageElement(imageElement);
+    }
+
+    final pixelRatio = _loadInfo.pixelRatio;
+    return renderTexture.quad.withPixelRatio(pixelRatio);
   }
 }
 

--- a/lib/stagexl.dart
+++ b/lib/stagexl.dart
@@ -185,4 +185,8 @@ class Environment {
   /// which support TouchEvents and therefore has a touch screen.
 
   final bool isTouchEventSupported = env.isTouchEventSupported;
+
+  /// This flag indicates whether bitmaps will be uploaded efficiently
+
+  final bool isImageBitmapSupported = env.isImageBitmapSupported;
 }

--- a/test/util/image_bitmap_test.dart
+++ b/test/util/image_bitmap_test.dart
@@ -11,8 +11,6 @@ void main() {
   late BitmapData spiders;
 
   setUp(() async {
-    StageXL.bitmapDataLoadOptions.imageBitmap = true;
-
     final resourceManager = ResourceManager();
     resourceManager.addBitmapData('spiders', '../common/images/spider.png');
     await resourceManager.load();

--- a/test/util/image_bitmap_test.dart
+++ b/test/util/image_bitmap_test.dart
@@ -21,7 +21,7 @@ void main() {
 
   test('render texture is an ImageBitmap', () {
     final image = spiders.renderTexture.imageBitmap;
-    expect(image is ImageBitmap, true);
+    expect(image is ImageBitmap, StageXL.environment.isImageBitmapSupported);
   });
 
   test('getImageData works', () {

--- a/test/util/image_bitmap_test.dart
+++ b/test/util/image_bitmap_test.dart
@@ -1,0 +1,42 @@
+@TestOn('browser')
+library image_bitmap_test;
+
+import 'dart:html' show ImageBitmap;
+import 'dart:math' show pi;
+
+import 'package:stagexl/stagexl.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late BitmapData spiders;
+
+  setUp(() async {
+    StageXL.bitmapDataLoadOptions.imageBitmap = true;
+
+    final resourceManager = ResourceManager();
+    resourceManager.addBitmapData('spiders', '../common/images/spider.png');
+    await resourceManager.load();
+    spiders = resourceManager.getBitmapData('spiders');
+  });
+
+  //---------------------------------------------------------------------------
+
+  test('render texture is an ImageBitmap', () {
+    final image = spiders.renderTexture.imageBitmap;
+    expect(image is ImageBitmap, true);
+  });
+
+  test('getImageData works', () {
+    final image = spiders.renderTexture.quad.getImageData();
+    expect(image.width, equals(224));
+    expect(image.height, equals(128));
+  });
+
+  test('rotation works', () {
+    final image = Bitmap(spiders);
+    image.rotation = toRadians(90);
+    expect(image.width, equals(128));
+  });
+}
+
+num toRadians(num degrees) => degrees * (pi / 180);


### PR DESCRIPTION
This results in more efficient usage of bitmaps, by reducing image
upload latency by saving a memory copy.

See https://developer.mozilla.org/en-US/docs/Web/API/ImageBitmap

Unfortunately, the Dart SDK still does not support this natively,
so we have to resort to some js_util hacks to get around this.

Closes https://github.com/bp74/StageXL/issues/351