### PR TITLE
Add null-check on format key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ announcements on the StageXL forum or use one of the support links below:
   * StageXL GitHub <https://github.com/bp74/StageXL/issues>
   * StageXL StackOverflow: <http://stackoverflow.com/questions/ask?tags=stagexl>
 
+### 2.0.3
+ * Fix a bug where the `meta["format"]` key was assumed to be non-null in json texture atlas filesj.
 ### 2.0.2
  * Exposing max texture size on WebGl canvas.
  * Exposing getParameters call on WebGL canvas.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ announcements on the StageXL forum or use one of the support links below:
   * StageXL GitHub <https://github.com/bp74/StageXL/issues>
   * StageXL StackOverflow: <http://stackoverflow.com/questions/ask?tags=stagexl>
 
+### 2.1.1
+ * Fix a bug where the `meta["format"]` key was assumed to be non-null in json texture atlas files.
+  
 ### 2.1.0
 * createImageBitmap support for Chrome, Edge, Firefox, and newer Safari (v15+).
 * Allowing pixel formats from sprite sheets

--- a/lib/src/resources/texture_atlas_format_json.dart
+++ b/lib/src/resources/texture_atlas_format_json.dart
@@ -16,7 +16,8 @@ class _TextureAtlasFormatJson extends TextureAtlasFormat {
     final renderTextureQuad = await loader.getRenderTextureQuad(image);
 
     //  Set texture info based on meta format
-    _setTextureFormat(renderTextureQuad.renderTexture, meta['format'] as String);
+    final format = meta['format'] as String?;
+    if (format != null) _setTextureFormat(renderTextureQuad.renderTexture, format);
 
     if (frames is List) {
       for (var frame in frames) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: stagexl
-version: 2.1.0
+version: 2.1.1
 description: A fast and universal 2D rendering engine for HTML5 and Dart.
 homepage: http://www.stagexl.org
 repository: https://github.com/bp74/StageXL

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: stagexl
-version: 2.0.2
+version: 2.0.3
 description: A fast and universal 2D rendering engine for HTML5 and Dart.
 homepage: http://www.stagexl.org
 repository: https://github.com/bp74/StageXL


### PR DESCRIPTION
All previous tests were done with json files generated by
Texture Packer, which I thought always had the "format" key. However,
that appears to not be the case.

Note that in the absence of the "format" key, the render texture defaults to rgba 8888, as before.